### PR TITLE
fix-#1: declarativeNetRequest로 API 접근 권한 방식 변경

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,33 +1,52 @@
-// 패턴 목록을 저장할 변수
-let patterns = [];
+// 정규표현식 특수문자 이스케이프
+function escapeRegex(string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
 
-// patterns.json 파일을 fetch API로 불러와서 patterns 변수에 저장
-fetch(chrome.runtime.getURL('patterns.json'))
-  .then((response) => response.json())
-  .then((data) => {
-    patterns = data;
-    console.log("URL patterns loaded:", patterns);
-  })
-  .catch((error) => console.error("Error loading patterns:", error));
+// 규칙 업데이트 함수
+async function updateRules() {
+  // patterns.json 불러오기
+  const response = await fetch(chrome.runtime.getURL('patterns.json'));
+  const patterns = await response.json();
 
-chrome.webRequest.onBeforeRequest.addListener(
-  function(details) {
-    const originalUrl = details.url;
+  // patterns.json로 declarativeNetRequest 규칙 생성
+  const rules = patterns.map((pattern, index) => {
+    // 정규표현식에 사용 가능하도록 특수문자 이스케이프
+    const escapedPattern = escapeRegex(pattern);
+    return {
+      id: index + 1,
+      priority: 1,
+      condition: {
+        // "프로토콜(패턴 + 나머지 주소)" 형태의 URL을 감지하는 정규표현식
+        regexFilter: '^https?:\\/\\/(${escapedPattern}.*)',
+        resourceTypes: ['main_frame']
+      },
+      action: {
+        type: 'redirect',
+        redirect: {
+          // 정규표현식을 사용하여 URL 재구성
+          regexSubstitution: 'https://libproxy.pknu.ac.kr/_Lib_Proxy_Url/\\1'
+        }
+      }
+    };
+  });
 
-    // 불러온 패턴 목록 중 하나라도 URL에 포함되는지 확인
-    const isMatch = patterns.some(pattern => originalUrl.includes(pattern));
 
-    if (isMatch) {
-      const proxyPrefix = "https://libproxy.pknu.ac.kr/_Lib_Proxy_Url/";
-      const urlWithoutProtocol = originalUrl.replace(/^https?:\/\//, '');
-      const modifiedUrl = proxyPrefix + urlWithoutProtocol;
+  // declarativeNetRequest로 생성된 동적 규칙의 영속성
 
-      return { redirectUrl: modifiedUrl };
-    }
-  },
-  {
-    urls: ["<all_urls>"], // 모든 URL 요청을 감시
-    types: ["main_frame"]
-  },
-  ["blocking"]
-);
+  // 기존 규칙 확인
+  const existingRules = await chrome.declarativeNetRequest.getDynamicRules();
+  const existingRuleIds = existingRules.map(rule => rule.id);
+  
+  await chrome.declarativeNetRequest.updateDynamicRules({
+    removeRuleIds: existingRuleIds, // 기존 규칙 전체 삭제
+    addRules: rules // 새 규칙 추가
+  });
+
+  console.log("Redirect rules updated successfully!", rules);
+}
+
+// 확장 프로그램이 처음 설치됐을 때, 업데이트될 때, 브라우저가 시작될 때 실행
+chrome.runtime.onInstalled.addListener(() => {
+  updateRules();
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,21 +1,15 @@
 {
   "manifest_version": 3,
   "name": "PKNU Library Proxy Redirector",
-  "version": "1.0",
+  "version": "2.0",
   "description": "링크를 부경대학교 도서관 프록시 서버로 연결합니다.",
   "permissions": [
-    "webRequest"
+    "declarativeNetRequest"
   ],
   "host_permissions": [
     "*://*/*"
   ],
   "background": {
     "service_worker": "background.js"
-  },
-  "web_accessible_resources": [
-    {
-      "resources": ["patterns.json"],
-      "matches": ["<all_urls>"]
-    }
-  ]
+  }
 }


### PR DESCRIPTION
기존 webRequest API 방식에서 Manifest V3와 ["blocking"]의 충돌이 발생했음.
declarativeNetRequest API 방식으로 변경하고, 동적으로 rule을 생성하도록 수정하여 문제 해결.
extension이 실행될 때마다 rule을 갱신하도록 하여 이전 rule과의 충돌 방지.